### PR TITLE
support GKI kernel modules building for android

### DIFF
--- a/build.config.virtual_device.riscv64
+++ b/build.config.virtual_device.riscv64
@@ -1,0 +1,12 @@
+. ${ROOT_DIR}/common-modules/virtual-device/build.config.virtual_device
+
+. ${ROOT_DIR}/${KERNEL_DIR}/build.config.riscv64
+
+DEFCONFIG=vd_riscv64_gki_defconfig
+PRE_DEFCONFIG_CMDS="KCONFIG_CONFIG=${ROOT_DIR}/${KERNEL_DIR}/arch/riscv/configs/${DEFCONFIG} ${ROOT_DIR}/${KERNEL_DIR}/scripts/kconfig/merge_config.sh -m -r ${ROOT_DIR}/${KERNEL_DIR}/arch/riscv/configs/gki_defconfig ${ROOT_DIR}/common-modules/virtual-device/virtual_device.fragment"
+POST_DEFCONFIG_CMDS="rm ${ROOT_DIR}/${KERNEL_DIR}/arch/riscv/configs/${DEFCONFIG}"
+BUILD_GOLDFISH_DRIVERS=m
+
+# Not building/saving any kernel images. This build step is meant purely to generate the .kos.
+FILES=""
+MAKE_GOALS="modules"

--- a/goldfish_drivers/defconfig_test.h
+++ b/goldfish_drivers/defconfig_test.h
@@ -20,7 +20,7 @@
 #error CONFIG_PCI is required
 #endif
 
-#if !defined(CONFIG_COMPAT) && !defined(CONFIG_COMPAT_32) && !defined(CONFIG_ARM)
+#if !defined(CONFIG_COMPAT) && !defined(CONFIG_COMPAT_32) && !defined(CONFIG_ARM) && !defined(CONFIG_RISCV)
 #error CONFIG_COMPAT or CONFIG_COMPAT_32 is required
 #endif
 


### PR DESCRIPTION
With this change, we can build kernel modules by:
`BUILD_CONFIG=common-modules/virtual-device/build.config.virtual_device.riscv64 build/build.sh -j $(nproc)`

FIXME: changes in defconfig_test.h may not be the best method, just to pass the build and restrain error reporting.

Signed-off-by: Wang Chen <wangchen20@iscas.ac.cn>